### PR TITLE
Fix send notification after 8hours

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - bin/rspec

--- a/lib/daily_notifier.rb
+++ b/lib/daily_notifier.rb
@@ -2,11 +2,12 @@ require 'pstore'
 require 'mailer'
 
 class DailyNotifier
-  BUSINESS_DAY_THRESHOLD = 8
+  MILISECONDS_PER_HOUR = 3_600_000
+  private_constant :MILISECONDS_PER_HOUR
+  DAILY_LIMIT_IN_MS = MILISECONDS_PER_HOUR * 8
+  private_constant :DAILY_LIMIT_IN_MS
 
   STORE = File.join(File.expand_path('..', __dir__), 'store', 'daily.pstore')
-
-  attr_reader :weekly_reports
 
   def initialize(weekly_reports, db)
     @weekly_reports = weekly_reports
@@ -32,6 +33,8 @@ class DailyNotifier
 
   private
 
+  attr_reader :weekly_reports
+
   def weekend_day_notification(report)
     Mailer.weekend_day_to_user(report.email, report: report)
     store_notification(report.email)
@@ -47,7 +50,7 @@ class DailyNotifier
   end
 
   def send_business_day_notification?(week_day, report)
-    report.day_hours(week_day) >= BUSINESS_DAY_THRESHOLD && last_sent(report.email) < Date.today
+    report.day_miliseconds(week_day) > DAILY_LIMIT_IN_MS && last_sent(report.email) < Date.today
   end
 
   def store_notification(email)

--- a/lib/weekly_user_report.rb
+++ b/lib/weekly_user_report.rb
@@ -26,11 +26,18 @@ class WeeklyUserReport
   end
 
   def day_hours(week_day)
-    data_slot = (week_day - 1) % 7
-    miliseconds_to_hours(@total_miliseconds[data_slot])
+    miliseconds_to_hours(@total_miliseconds[data_slot_index(week_day)])
+  end
+
+  def day_miliseconds(week_day)
+    @total_miliseconds[data_slot_index(week_day)]
   end
 
   private
+
+  def data_slot_index(week_day)
+    (week_day - 1) % 7
+  end
 
   def miliseconds_to_hours(miliseconds)
     return 0.0 if miliseconds.nil?

--- a/spec/daily_notifier_spec.rb
+++ b/spec/daily_notifier_spec.rb
@@ -6,65 +6,102 @@ describe DailyNotifier do
       db = double(:db)
       row = double(:row)
       allow(db).to receive(:[]).and_return(row)
+      allow(row).to receive(:insert).and_return([])
       allow(row).to receive(:where).and_return([])
       db
     end
-    let(:daily_notifier) { described_class.new(weekly_reports, db) }
+    let(:employee_flag) { true }
     let(:weekly_user_report) do
-      WeeklyUserReport.new('1', 'John Doe', 'john@doe.com', true, working_time)
+      WeeklyUserReport.new('1', 'John Doe', 'john@doe.com', employee_flag, input_time_struct)
     end
     let(:weekly_reports) { [weekly_user_report] }
+    let(:daily_notifier) { described_class.new(weekly_reports, db) }
 
-    context 'user worked more than 8 hours in a business day' do
-      let(:working_time) { [nil, nil, 28_800_000, nil, nil, nil, nil, 28_800_000] }
+    let(:miliseconds_per_hour) { 3_600_000 }
+    let(:eight_hours_in_ms) { 8 * miliseconds_per_hour }
 
-      it 'sends business day notification' do
-        allow(Date).to receive(:today) { Date.new(2015, 10, 28) }
-        expect(daily_notifier).to receive(:business_day_notification)
-        daily_notifier.call
+    context 'on a business day' do
+      let(:business_day) { Date.new(2015, 10, 28) }
+      before { Timecop.freeze(business_day) }
+      after { Timecop.return }
+
+      let(:input_time_struct) do
+        [nil, nil, worked_time_in_ms , nil, nil, nil, nil, worked_time_in_ms]
       end
-    end
 
-    context 'user worked less than 8 hours in a business day' do
-      let(:working_time) { [nil, nil, 28_799_999, nil, nil, nil, nil, 28_799_999] }
+      context 'user worked more than 8 hours' do
+        let(:worked_time_in_ms) { eight_hours_in_ms + 1 }
 
-      it 'does not send bussiness day notification' do
-        allow(Date).to receive(:today) { Date.new(2015, 10, 28) }
-        expect(daily_notifier).not_to receive(:business_day_notification)
-        daily_notifier.call
-      end
-    end
-
-    context 'work at the weekend' do
-      let(:working_time) { [nil, nil, nil, nil, nil, 3_600_000, nil, 3_600_000] }
-      context 'employee' do
-        it 'sends weekend notification' do
-          allow(Date).to receive(:today) { Date.new(2015, 10, 31) }
-          expect(daily_notifier).to receive(:weekend_day_notification)
+        it 'sends business day notification' do
+          expect(Mailer)
+            .to receive(:daily_to_user)
+            .with(weekly_user_report.email, report: weekly_user_report)
           daily_notifier.call
         end
       end
 
-      context 'contractor' do
-        let(:weekly_user_report) do
-          WeeklyUserReport.new('1', 'John Doe', 'john@doe.com', false, working_time)
-        end
+      context 'user worked exactly 8 hours' do
+        let(:worked_time_in_ms) { eight_hours_in_ms }
 
-        it 'sends weekend notification' do
-          allow(Date).to receive(:today) { Date.new(2015, 10, 31) }
-          expect(daily_notifier).not_to receive(:weekend_day_notification)
+        it 'does not send business day notification' do
+          expect(Mailer)
+            .not_to receive(:daily_to_user)
+          daily_notifier.call
+        end
+      end
+
+      context 'user worked less than 8 hours' do
+        let(:worked_time_in_ms) { eight_hours_in_ms - 1 }
+
+        it 'does not send bussiness day notification' do
+          expect(Mailer)
+            .not_to receive(:daily_to_user)
           daily_notifier.call
         end
       end
     end
 
-    context 'employee did not work at the weekend' do
-      let(:working_time) { [nil, nil, nil, nil, nil, 0, nil, 0] }
-      context 'employee' do
-        it 'does not send weekend notification' do
-          allow(Date).to receive(:today) { Date.new(2015, 10, 31) }
-          expect(daily_notifier).not_to receive(:weekend_day_notification)
-          daily_notifier.call
+    context 'at the weekend' do
+      let(:weekend_day) { Date.new(2015, 10, 31) }
+      before { Timecop.freeze(weekend_day) }
+      after { Timecop.return }
+
+      let(:input_time_struct) do
+        [nil, nil, nil, nil, nil, worked_time_in_ms, nil, worked_time_in_ms]
+      end
+
+      context 'worked one hour' do
+        let(:worked_time_in_ms) { miliseconds_per_hour }
+
+        context 'and for employee' do
+          it 'sends weekend notification' do
+            expect(Mailer)
+              .to receive(:weekend_day_to_user)
+              .with(weekly_user_report.email, report: weekly_user_report)
+            daily_notifier.call
+          end
+        end
+
+        context 'and for contractor' do
+          let(:employee_flag) { false }
+
+          it 'sends weekend notification' do
+            expect(Mailer)
+              .not_to receive(:weekend_day_to_user)
+            daily_notifier.call
+          end
+        end
+      end
+
+      context 'did not work' do
+        let(:worked_time_in_ms) { 0 }
+
+        context 'and for employee' do
+          it 'does not send weekend notification' do
+            expect(Mailer)
+              .not_to receive(:weekend_day_to_user)
+            daily_notifier.call
+          end
         end
       end
     end

--- a/spec/daily_notifier_spec.rb
+++ b/spec/daily_notifier_spec.rb
@@ -85,7 +85,7 @@ describe DailyNotifier do
         context 'and for contractor' do
           let(:employee_flag) { false }
 
-          it 'sends weekend notification' do
+          it 'does not send weekend notification' do
             expect(Mailer)
               .not_to receive(:weekend_day_to_user)
             daily_notifier.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,6 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-
-require 'timecop'
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'timecop'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
### Description
- Change default behavior: Send daily emails after passing 8 hours instead of reaching 8 hours.

### Sign offs
- [x] @lubieniebieski 
