### PR TITLE
Monthly reports with list of invalid toggl entries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "pony"
 gem "rake"
 gem "sequel"
 gem "pg"
+gem "pry"
 
 group :development, :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
     httparty (0.13.7)
@@ -9,11 +10,16 @@ GEM
     json (1.8.3)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.2)
     multi_xml (0.5.5)
     pg (0.18.3)
     pony (1.11)
       mail (>= 2.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -29,6 +35,7 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     sequel (4.28.0)
+    slop (3.6.0)
     timecop (0.7.1)
 
 PLATFORMS
@@ -39,6 +46,7 @@ DEPENDENCIES
   httparty
   pg
   pony
+  pry
   rake
   rspec
   sequel

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ SEND_WEEKLY_EVERY_DAY - used for testing
 DATABASE_URL - database connection data
 SENDGRID_USERNAME - SendGrid user name
 SENDGRID_PASSWORD - SendGrid user password
+DINNER_PID - Project id of dinner
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Netguru Toggl notifier
 
 Application sends notifications about working hours basing on toggl reports.
-Daily reports are sent to users when they worked longer than 8 hours/day. Weekly report is sent to office on monday and it contains list of these users who worked longer than 40 hours in the previous week.
+
+Daily reports are sent to users when they worked longer than 8 hours/day.
+
+Weekly report is sent to office on monday and it contains list of these users who worked longer than 40 hours in the previous week.
+
+Monthly report looks for invalid entries (too long dinner, entry without a project) and sends to users lists of them.
 
 ### Usage
 
@@ -20,17 +25,24 @@ Sending to office weekly reports:
 bin/rake send_weekly
 ```
 
+Sending monthly reports
+```
+bin/rake send_monthly - for current year and month
+bin/rake send_monthly[2016,4] - for specific year and month
+bin/rake send_monthly[2016,4,true] - force resending for specific year and month
+```
+
 ### Environment vairables
 ```
 APP_ENV - application environment
 COMPANY_NAME - company name (Toggl workspace name)
 OFFICE_EMAIL - sender of all reports, recipient of weekly reports
 TOGGL_TOKEN - Toggl API token
-SEND_WEEKLY_EVERY_DAY - used for testing
-DATABASE_URL - database connection data
+DATABASE_URL - database connection data (for example `postgres://ng-toggl-notifier@localhost/ng-toggl-notifier`)
 SENDGRID_USERNAME - SendGrid user name
 SENDGRID_PASSWORD - SendGrid user password
-
+SEND_WEEKLY_EVERY_DAY - used for testing
+TEST_EMAIL (optional) - used for testing, send all emails to this email account
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ SEND_WEEKLY_EVERY_DAY - used for testing
 DATABASE_URL - database connection data
 SENDGRID_USERNAME - SendGrid user name
 SENDGRID_PASSWORD - SendGrid user password
-DINNER_PID - Project id of dinner
 
 ```
 

--- a/db/migrations/002_create_sent_monthly.rb
+++ b/db/migrations/002_create_sent_monthly.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    create_table(:sent_monthly) do
+      primary_key :id
+      String :email, null: false, unique: true
+      Date :sent_at, null: false
+    end
+  end
+
+  down do
+    drop_table(:sent_monthly)
+  end
+end

--- a/db/migrations/002_create_sent_monthly.rb
+++ b/db/migrations/002_create_sent_monthly.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   up do
     create_table(:sent_monthly) do
       primary_key :id
-      String :email, null: false, unique: true
+      String :email, null: false
       Date :sent_at, null: false
     end
   end

--- a/db/migrations/003_create_executed_monthly.rb
+++ b/db/migrations/003_create_executed_monthly.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    create_table(:executed_monthly) do
+      primary_key :id
+      Integer :year, null: false
+      Integer :month, null: false
+    end
+  end
+
+  down do
+    drop_table(:executed_monthly)
+  end
+end

--- a/lib/mailer.rb
+++ b/lib/mailer.rb
@@ -4,34 +4,27 @@ class Mailer
   TEMPLATES_DIR = File.join(File.expand_path('..', __dir__), 'templates')
 
   def self.weekly_to_office(data = {})
-    Pony.mail(
-      to: ENV['OFFICE_EMAIL'],
-      subject: 'Toggl weekly report',
-      body: render(data)
-    )
+    mail(ENV['OFFICE_EMAIL'], 'Toggl weekly report', render(data))
   end
 
   def self.daily_to_user(email, data = {})
-    Pony.mail(
-      to: email,
-      subject: 'Toggl daily report',
-      body: render(data)
-    )
+    mail(email, 'Toggl daily report', render(data))
   end
 
   def self.weekend_day_to_user(email, data = {})
-    Pony.mail(
-      to: email,
-      subject: 'Toggl weekend report',
-      body: render(data)
-    )
+    mail(email, 'Toggl weekend report', render(data))
   end
 
   def self.monthly_to_user(email, data = {})
+    mail(email, 'Toggl monthly report', render(data))
+  end
+
+  def self.mail(email, subject, data)
+    email_to = ENV['TEST_EMAIL'] || email
     Pony.mail(
-      to: email,
-      subject: 'Toggl monthly report',
-      body: render(data)
+      to: email_to,
+      subject: subject,
+      body: data
     )
   end
 

--- a/lib/mailer.rb
+++ b/lib/mailer.rb
@@ -27,6 +27,14 @@ class Mailer
     )
   end
 
+  def self.monthly_to_user(email, data = {})
+    Pony.mail(
+      to: email,
+      subject: 'Toggl monthly report',
+      body: render(data)
+    )
+  end
+
   def self.render(data = {})
     template_name = caller[0][/`.*'/][1..-2]
     template_path = File.join(TEMPLATES_DIR, "#{template_name}.txt")

--- a/lib/monthly_notifier.rb
+++ b/lib/monthly_notifier.rb
@@ -2,15 +2,25 @@ require 'pstore'
 require 'mailer'
 
 class MonthlyNotifier
-  def call(monthly_reports)
-    monthly_reports.each do |report|
-      send_monthly_notification(report) if report.employee
+  def initialize(monthly_reports, db)
+    @monthly_reports = monthly_reports
+    @db = db
+  end
+
+  def call
+    @monthly_reports.each do |report|
+      send_monthly_notification(report)
     end
   end
 
   private
 
   def send_monthly_notification(report)
-    Mailer.monthly_to_user(monthly_report.email, report: report)
+    Mailer.monthly_to_user(report.email, report: report)
+    store_notification(report.email)
+  end
+
+  def store_notification(email)
+    @db[:sent_monthly].insert(email: email, sent_at: Date.today)
   end
 end

--- a/lib/monthly_notifier.rb
+++ b/lib/monthly_notifier.rb
@@ -8,8 +8,10 @@ class MonthlyNotifier
   end
 
   def call
-    @monthly_reports.each do |report|
-      send_monthly_notification(report) if report.employee
+    emails_count = @monthly_reports.count
+    @monthly_reports.each_with_index do |report, index|
+      send_monthly_notification(report) if report.employee || true
+      puts "Sent email #{index + 1}/#{emails_count}"
     end
   end
 

--- a/lib/monthly_notifier.rb
+++ b/lib/monthly_notifier.rb
@@ -9,7 +9,7 @@ class MonthlyNotifier
 
   def call
     @monthly_reports.each do |report|
-      send_monthly_notification(report)
+      send_monthly_notification(report) if report.employee
     end
   end
 

--- a/lib/monthly_notifier.rb
+++ b/lib/monthly_notifier.rb
@@ -1,0 +1,16 @@
+require 'pstore'
+require 'mailer'
+
+class MonthlyNotifier
+  def call(monthly_reports)
+    monthly_reports.each do |report|
+      send_monthly_notification(report) if report.employee
+    end
+  end
+
+  private
+
+  def send_monthly_notification(report)
+    Mailer.monthly_to_user(monthly_report.email, report: report)
+  end
+end

--- a/lib/monthly_user_report.rb
+++ b/lib/monthly_user_report.rb
@@ -1,0 +1,13 @@
+class MonthlyUserReport
+  attr_reader :uid, :user_name, :email, :employee
+  attr_accessor :invalid_dinner_entries, :invalid_project_entries
+
+  def initialize(uid, user_name, email, employee)
+    @uid = uid
+    @user_name = user_name
+    @email = email
+    @employee = employee
+    @invalid_dinner_entries = []
+    @invalid_project_entries = []
+  end
+end

--- a/lib/monthly_user_report.rb
+++ b/lib/monthly_user_report.rb
@@ -10,4 +10,31 @@ class MonthlyUserReport
     @invalid_dinner_entries = []
     @invalid_project_entries = []
   end
+
+  def formatted_entries(entry_type)
+    entries = entry_type == :dinner ? invalid_dinner_entries : invalid_project_entries
+    entries.map do |entry|
+      {
+        start: format_date(entry['start']),
+        end: format_date(entry['end']),
+        duration: format_duration(entry['dur'])
+      }
+    end
+  end
+
+  private
+
+  def format_date(date)
+    Time.iso8601(date).strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  def format_duration(miliseconds)
+    x = miliseconds / 1000
+    seconds = x % 60
+    x /= 60
+    minutes = x % 60
+    x /= 60
+    hours = x % 24
+    [hours, minutes, seconds].map { |e| e.to_s.rjust(2,'0') }.join ':'
+  end
 end

--- a/lib/monthly_user_report.rb
+++ b/lib/monthly_user_report.rb
@@ -2,13 +2,13 @@ class MonthlyUserReport
   attr_reader :uid, :user_name, :email, :employee
   attr_accessor :invalid_dinner_entries, :invalid_project_entries
 
-  def initialize(uid, user_name, email, employee)
+  def initialize(uid, user_name, email, employee, invalid_dinner_entries = [], invalid_project_entries = [])
     @uid = uid
     @user_name = user_name
     @email = email
     @employee = employee
-    @invalid_dinner_entries = []
-    @invalid_project_entries = []
+    @invalid_dinner_entries = invalid_dinner_entries
+    @invalid_project_entries = invalid_project_entries
   end
 
   def formatted_entries(entry_type)

--- a/lib/monthly_user_reports_builder.rb
+++ b/lib/monthly_user_reports_builder.rb
@@ -33,6 +33,6 @@ class MonthlyUserReportsBuilder
   end
 
   def too_long_dinner?(entry)
-    entry['pid'] == ENV['DINNER_PID'].to_i && entry['dur'] > DINNER_MAX_ENTRY_TIME_IN_MILISECONDS
+    entry['project'].to_s.downcase == 'dinner' && entry['dur'] > DINNER_MAX_ENTRY_TIME_IN_MILISECONDS
   end
 end

--- a/lib/monthly_user_reports_builder.rb
+++ b/lib/monthly_user_reports_builder.rb
@@ -1,0 +1,38 @@
+require 'monthly_user_report'
+
+class MonthlyUserReportsBuilder
+  DINNER_MAX_ENTRY_TIME_IN_MILISECONDS = 1_800_000 # 30 min
+  private_constant :DINNER_MAX_ENTRY_TIME_IN_MILISECONDS
+
+  def build(entries, users_emails)
+    entries.each_with_object([]) do |entry, reports|
+      next unless invalid_entry?(entry)
+      uid = entry['uid']
+      report = reports.find { |report| report.uid == uid }
+      new_report = report.nil?
+      report ||= MonthlyUserReport.new(
+        uid,
+        entry['user'],
+        users_emails[uid][:email],
+        users_emails[uid][:employee]
+      )
+      report.invalid_dinner_entries << entry if too_long_dinner?(entry)
+      report.invalid_project_entries << entry if without_project?(entry)
+      reports << report if new_report
+    end
+  end
+
+  private
+
+  def invalid_entry?(entry)
+    without_project?(entry) || too_long_dinner?(entry)
+  end
+
+  def without_project?(entry)
+    entry['pid'].nil?
+  end
+
+  def too_long_dinner?(entry)
+    entry['pid'] == ENV['DINNER_PID'].to_i && entry['dur'] > DINNER_MAX_ENTRY_TIME_IN_MILISECONDS
+  end
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -27,11 +27,10 @@ task :send_daily => :environment do
 end
 
 desc "Monthly reports"
-task :send_monthly, [:year, :month] => :environment do |_, args|
   year = args.year || Date.today.year
   month = args.month || Date.today.month
   db = Sequel.connect(ENV['DATABASE_URL'])
-  if db[:executed_monthly].where(year: year, month: month).count > 0
+  if !args.force && db[:executed_monthly].where(year: year, month: month).count > 0
     fail 'Monthly report already sent'
   end
   puts "Sending monthly..."

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -27,8 +27,9 @@ task :send_daily => :environment do
 end
 
 desc "Monthly reports"
-  year = args.year || Date.today.year
-  month = args.month || Date.today.month
+task :send_monthly, [:year, :month, :force] => :environment do |_, args|
+  year = (args.year || Date.today.year).to_i
+  month = (args.month || Date.today.month).to_i
   db = Sequel.connect(ENV['DATABASE_URL'])
   if !args.force && db[:executed_monthly].where(year: year, month: month).count > 0
     fail 'Monthly report already sent'

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,6 +1,7 @@
 require 'toggl_reports_client'
 require 'daily_notifier'
 require 'weekly_notifier'
+require 'monthly_notifier'
 
 desc "Weekly reports"
 task :send_weekly => :environment do
@@ -25,3 +26,14 @@ task :send_daily => :environment do
   puts "done."
 end
 
+desc "Monthly reports"
+task :send_monthly, [:year, :month] => :environment do |_, args|
+  year = args.year || Date.today.year
+  month = args.month || Date.today.month
+  puts "Sending monthly..."
+  debugging_on= ENV['DEBUG'] == "true"
+  report_client = TogglReportsClient.new(ENV['TOGGL_TOKEN'], ENV['COMPANY_NAME'], debugging_on)
+  monthly_reports = report_client.monthly_user_reports(year.to_i, month.to_i)
+  MonthlyNotifier.new.call(monthly_reports)
+  puts "done."
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -28,6 +28,7 @@ end
 
 desc "Monthly reports"
 task :send_monthly, [:year, :month] => :environment do |_, args|
+  fail 'Set DINNER_PID env' if ENV['DINNER_PID'].nil?
   year = args.year || Date.today.year
   month = args.month || Date.today.month
   puts "Sending monthly..."

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -28,7 +28,6 @@ end
 
 desc "Monthly reports"
 task :send_monthly, [:year, :month] => :environment do |_, args|
-  fail 'Set DINNER_PID env' if ENV['DINNER_PID'].nil?
   year = args.year || Date.today.year
   month = args.month || Date.today.month
   db = Sequel.connect(ENV['DATABASE_URL'])

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -39,7 +39,7 @@ task :send_monthly, [:year, :month] => :environment do |_, args|
   debugging_on= ENV['DEBUG'] == "true"
   report_client = TogglReportsClient.new(ENV['TOGGL_TOKEN'], ENV['COMPANY_NAME'], debugging_on)
   monthly_reports = report_client.monthly_user_reports(year, month)
-  MonthlyNotifier.new.call(monthly_reports)
+  MonthlyNotifier.new(monthly_reports, db).call
   db[:executed_monthly].insert(year: year, month: month)
   puts "done."
 end

--- a/lib/toggl_reports_client.rb
+++ b/lib/toggl_reports_client.rb
@@ -24,6 +24,19 @@ class TogglReportsClient
       .map { |ur| WeeklyUserReport.build_from_api(ur, users_data) }
   end
 
+  def monthly_user_reports(year, month)
+    return @monthly_users_report if defined?(@monthly_users_report)
+    beggining_of_the_month = Date.new(year, month, 1)
+    end_of_the_month = Date.new(year, month, -1)
+    query = {
+      workspace_id: workspace['id'],
+      since: beggining_of_the_month.strftime('%Y-%m-%d'),
+      until: end_of_the_month.strftime('%Y-%m-%d')
+    }
+    entries_data = HTTParty.get('/details', http_options(query: query))['data']
+    @monthly_users_report = MonthlyUserReportsBuilder.new.build(entries_data, users_data)
+  end
+
   private
 
   def workspace

--- a/lib/toggl_reports_client.rb
+++ b/lib/toggl_reports_client.rb
@@ -1,4 +1,5 @@
 require 'weekly_user_report'
+require 'monthly_user_reports_builder'
 
 class TogglReportsClient
   DATA_API_URI = 'https://toggl.com/api/v8'

--- a/spec/monthly_notifier_spec.rb
+++ b/spec/monthly_notifier_spec.rb
@@ -1,0 +1,23 @@
+require 'monthly_notifier'
+
+describe MonthlyNotifier do
+  let(:entry) { {'start' => '2016-01-01T17:30:10+02:00', 'end' => '2016-01-01T19:30:10+02:00', 'dur' => 3666600} }
+
+  let(:first_report) { MonthlyUserReport.new(1, 'user_name', 'email@example.com', 'employee', [entry]) }
+  let(:second_report) { MonthlyUserReport.new(1, 'user_name', 'email2@example.com', 'employee', [entry]) }
+  let(:monthly_reports) { [first_report, second_report] }
+  let(:db) do
+    db = double(:db)
+    row = double(:row)
+    allow(db).to receive(:[]).and_return(row)
+    allow(row).to receive(:insert).and_return([])
+    db
+  end
+  subject { described_class.new(monthly_reports, db) }
+
+  it 'sends monthly notification for each report' do
+    expect(Mailer).to receive(:monthly_to_user).with('email@example.com', report: first_report)
+    expect(Mailer).to receive(:monthly_to_user).with('email2@example.com', report: second_report)
+    subject.call
+  end
+end

--- a/spec/monthly_user_report_spec.rb
+++ b/spec/monthly_user_report_spec.rb
@@ -2,9 +2,7 @@ require 'monthly_user_report'
 
 describe MonthlyUserReport do
   let(:entry) { {'start' => '2016-01-01T17:30:10+02:00', 'end' => '2016-01-01T19:30:10+02:00', 'dur' => 3666600} }
-  let(:report) { described_class.new(1, 'user_name', 'email@example.com', 'employee') }
-
-  before { report.invalid_dinner_entries << entry }
+  let(:report) { described_class.new(1, 'user_name', 'email@example.com', 'employee', [entry]) }
 
   subject { report.formatted_entries(:dinner) }
 

--- a/spec/monthly_user_report_spec.rb
+++ b/spec/monthly_user_report_spec.rb
@@ -1,0 +1,24 @@
+require 'monthly_user_report'
+
+describe MonthlyUserReport do
+  let(:entry) { {'start' => '2016-01-01T17:30:10+02:00', 'end' => '2016-01-01T19:30:10+02:00', 'dur' => 3666600} }
+  let(:report) { described_class.new(1, 'user_name', 'email@example.com', 'employee') }
+
+  before { report.invalid_dinner_entries << entry }
+
+  subject { report.formatted_entries(:dinner) }
+
+  describe '#formatted_entries' do
+    it 'formats start date correctly' do
+      expect(subject.first[:start]).to eq '2016-01-01 17:30:10'
+    end
+
+    it 'formats end date correctly' do
+      expect(subject.first[:end]).to eq '2016-01-01 19:30:10'
+    end
+
+    it 'formats duration time correctly' do
+      expect(subject.first[:duration]).to eq '01:01:06'
+    end
+  end
+end

--- a/spec/monthly_user_reports_builder_spec.rb
+++ b/spec/monthly_user_reports_builder_spec.rb
@@ -1,0 +1,54 @@
+require 'monthly_user_reports_builder'
+
+describe MonthlyUserReportsBuilder do
+  let(:user_emails) do
+    {
+      1 => { email: "user@example.com", employee: true },
+      2 => { email: "user2@example.com", employee: true },
+      3 => { email: "user3@example.com", employee: true }
+    }
+  end
+  let(:dinner_valid)    { {"pid" => 1, "uid" => 1, "project" => "dinner", "dur" => 1, "user" => 'user'} }
+  let(:dinner_invalid)  { {"pid" => 1, "uid" => 1, "project" => "dinner", "dur" => 1_800_001, "user" => 'user'} }
+  let(:project_valid)   { {"pid" => 1, "uid" => 1, "project" => "project", "dur" => 1, "user" => 'user'} }
+  let(:project_invalid) { {"pid" => nil, "uid" => 1, "project" => nil, "dur" => 1, "user" => 'user'} }
+  let(:project_invalid_user2) { {"pid" => nil, "uid" => 2, "project" => nil, "dur" => 1, "user" => 'user'} }
+
+  subject { MonthlyUserReportsBuilder.new.build(entries, user_emails) }
+
+  let(:entries) { [dinner_valid, dinner_invalid, project_valid, project_invalid, project_invalid_user2] }
+
+  it 'returns as many reports as users with invalid projects' do
+    expect(subject.count).to eq 2
+  end
+
+  it 'assigns invalid dinner entries to users' do
+    expect(subject.first.invalid_dinner_entries).to eq [dinner_invalid]
+    expect(subject.last.invalid_dinner_entries).to eq []
+  end
+
+  it 'assigns invalid project entries to users' do
+    expect(subject.first.invalid_project_entries).to eq [project_invalid]
+    expect(subject.last.invalid_project_entries).to eq [project_invalid_user2]
+  end
+
+  it 'assigns user email to report' do
+    expect(subject.first.email).to eq 'user@example.com'
+  end
+
+  it 'assigns user employee status to report' do
+    expect(subject.first.employee).to eq true
+  end
+
+  it 'assigns entry username to report' do
+    expect(subject.first.user_name).to eq 'user'
+  end
+
+  context 'all entries are valid' do
+    let(:entries) { [dinner_valid, project_valid] }
+
+    it 'returns no reports' do
+      expect(subject).to eq []
+    end
+  end
+end

--- a/spec/toggl_reports_client_spec.rb
+++ b/spec/toggl_reports_client_spec.rb
@@ -13,6 +13,27 @@ describe TogglReportsClient do
       Timecop.return
     end
 
+    describe '#monthly_user_reports' do
+      it 'passes proper parameters to http get query' do
+        allow(client).to receive(:users_data)
+        expect(HTTParty).to receive(:get).with('/details',
+          {
+            :base_uri=>"https://toggl.com/reports/api/v2",
+            :query=> {
+              "user_agent" =>"support@netguru.co",
+              :workspace_id => 1,
+              :since => "2015-10-01",
+              :until => "2015-10-31"},
+              :basic_auth => {:username=>"toggl_token", :password=>"api_token"
+            },
+            :debug_output => $stdout
+          })
+        .and_return({ 'data' => [] })
+
+        client.monthly_user_reports(2015, 10)
+      end
+    end
+
     context 'current_week' do
       it 'passes proper paramters to http get query' do
         expect(HTTParty).to receive(:get).with('/weekly',

--- a/templates/monthly_to_user.txt
+++ b/templates/monthly_to_user.txt
@@ -1,0 +1,17 @@
+Hi!
+
+You have some invalid toggle entries. List of them down below.
+
+<% if report.invalid_dinner_entries.any? %>
+  Dinners:
+  <% report.formatted_entries(:dinner).each do |entry| %>
+    <%= entry[:duration] %> | <%= entry[:start] %> - <%= entry[:end] %>
+  <% end %>
+<% end %>
+
+<% if report.invalid_project_entries.any? %>
+  Without projects:
+  <% report.formatted_entries(:projects).each do |entry| %>
+    <%= entry[:duration] %> | <%= entry[:start] %> - <%= entry[:end] %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
# Description
Monthly reports that look for invalid entries (too long dinner, entry without a project) and send to users lists of them. 

For office
* Easier than checking manually and pinging people
* More sensible than cutting hours without warning

It could be scheduled to run at the end of every month. I don't know how it is handled now, some kind of cron I suppose?

# Sign-offs:
- [ ] @lubieniebieski 