### PR TITLE
Daily overtime notification limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Application sends notifications about working hours basing on toggl reports.
 
 Daily notifications are sent to users who exceed their total working time (8h/day) during the week.
+Notification is sent in overtime is 10 minutes or longer.
 
 Weekly report is sent to office on monday and it contains list of these users who worked longer than 40 hours in the previous week.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Application sends notifications about working hours basing on toggl reports.
 
 Daily notifications are sent to users who exceed their total working time (8h/day) during the week.
-Notification is sent in overtime is 10 minutes or longer.
+Notification is not sent when overtime is less than 10 minutes.
 
 Weekly report is sent to office on monday and it contains list of these users who worked longer than 40 hours in the previous week.
 

--- a/lib/daily_notifier.rb
+++ b/lib/daily_notifier.rb
@@ -4,6 +4,7 @@ require 'weekly_user_report'
 
 class DailyNotifier
   STORE = File.join(File.expand_path('..', __dir__), 'store', 'daily.pstore')
+  OVERTIME_NOTIFICATION_LIMIT = 600_000 # 10 minutes
 
   def initialize(weekly_reports, db)
     @weekly_reports = weekly_reports
@@ -45,7 +46,13 @@ class DailyNotifier
   end
 
   def send_overtime_notification?(week_day, report)
-    report.overtime_at?(week_day) && last_sent(report.email) < Date.today
+    report.overtime_at?(week_day) &&
+      over_overtime_notification_limit?(week_day, report) &&
+      last_sent(report.email) < Date.today
+  end
+
+  def over_overtime_notification_limit?(week_day, report)
+    report.overtime_milliseconds_at(week_day) >= OVERTIME_NOTIFICATION_LIMIT
   end
 
   def store_notification(email)


### PR DESCRIPTION
Notification is not sent if overtime is less than 10 minutes

It's pretty annoying to get messages like
`This week you have 0 hours and 0 minutes overtime so far! Chill out tomorrow :)`